### PR TITLE
Allow pandas 0.16 in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ setup(
         # NB: keep this in sync with vis/requirements.txt and vis/optional_requirements.txt
         # NB2: I left out the optional requirements and mock, since they aren't *required*
         'music21 (>=2.0.3, <2.1)',
-        'pandas (>=0.14.1, <0.16)',
+        'pandas (>=0.14.1, <0.17)',
         ],
     install_requires = [
         'music21 >= 2.0.3, <2.1',
-        'pandas >=0.14.1, <0.16',
+        'pandas >=0.14.1, <0.17',
         ],
     dependency_links = [
         # music21 2.0.3 has not been released to PyPl yet (2015-05-20).

--- a/vis/requirements.txt
+++ b/vis/requirements.txt
@@ -2,7 +2,7 @@
 # Certain functionality will be missing; see optional_requirements.txt.
 # music21>=2.0.3,<2.1
 -e git://github.com/cuthbertLab/music21.git@3fb33def708602485eadc1a655ede2fe22acb766 # Use this until released
-pandas>=0.14.1,<0.16
+pandas>=0.14.1,<0.17
 mock>=1.0.1
 coverage
 python-coveralls


### PR DESCRIPTION
Currently pandas<0.16 is specified in the requirements. However, the tests pass with version 0.16 so I assume this can be updated? This will avoid pip downloading and installing an older version in case 0.16 is already installed. Please feel free to close this PR if for some reason vis should not use the latest version of pandas.