### PR TITLE
Dependency cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,6 @@ setup(
         'music21 >= 2.0.3, <2.1',
         'pandas >=0.14.1, <0.17',
         ],
-    dependency_links = [
-        # music21 2.0.3 has not been released to PyPl yet (2015-05-20).
-        # This particular commit fixes an issue with exporting fermatas on rests.
-        "https://github.com/cuthbertLab/music21/archive/3fb33def708602485eadc1a655ede2fe22acb766.zip#egg=music21-2.0.3"
-    ],
     packages = [
         'vis',
         'vis.models',

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ setup(
         # NB: keep this in sync with vis/requirements.txt and vis/optional_requirements.txt
         # NB2: I left out the optional requirements and mock, since they aren't *required*
         'music21 (>=2.0.3, <2.1)',
-        'pandas (>=0.14.1, <0.16)',
+        'pandas (>=0.14.1, <0.17)',
         ],
     install_requires = [
         'music21 >= 2.0.3, <2.1',
-        'pandas >=0.14.1, <0.16',
+        'pandas >=0.14.1, <0.17',
         ],
     dependency_links = [
         # music21 2.0.3 has not been released to PyPl yet (2015-05-20).

--- a/vis/requirements.txt
+++ b/vis/requirements.txt
@@ -1,7 +1,7 @@
 # These packages are required for vis.
 # Certain functionality will be missing; see optional_requirements.txt.
 music21>=2.0.3,<2.1
-pandas>=0.14.1,<0.16
+pandas>=0.14.1,<0.17
 mock>=1.0.1
 coverage
 python-coveralls


### PR DESCRIPTION
Allow pandas 0.16.x and remove special dependency_link for music21 (since versions >= 2.0.3 were released a while ago).