### PR TITLE
Revert "Remove "outputlilypond" submodule in favour of using the PyPI package"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "outputlilypond"]
+	path = outputlilypond
+	url = git://github.com/crantila/outputlilypond.git

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 # Filename:               setup.py
 # Purpose:                Distutils Information for the VIS Framework
 #
-# Copyright (C) 2014, 2016 Christopher Antila
+# Copyright (C) 2014 Christopher Antila
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -53,15 +53,13 @@ setup(
         'music21 (== 2.1.2)',
         'pandas (== 0.18.1)',
         'multi_key_dict (== 2.0.3)',
-        'requests (== 2.11.1)',
-        'outputlilypond',
+	'requests (== 2.11.1)'
         ],
     install_requires = [
         'music21 == 2.1.2',
         'pandas == 0.18.1',
         'multi_key_dict == 2.0.3',
-        'requests == 2.11.1',
-        'outputlilypond',
+	'requests == 2.11.1'
         ],
     packages = [
         'vis',
@@ -69,15 +67,15 @@ setup(
         'vis.analyzers',
         'vis.analyzers.indexers',
         'vis.analyzers.experimenters',
+        'outputlilypond',
         ],
     package_data = {'vis': ['scripts/*']},
     classifiers = [
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Natural Language :: English",
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Environment :: Console",
         "Environment :: Web Environment",
         "Intended Audience :: End Users/Desktop",

--- a/vis/analyzers/experimenters/lilypond.py
+++ b/vis/analyzers/experimenters/lilypond.py
@@ -38,13 +38,9 @@ from math import fsum
 from numpy import isnan, NaN  # pylint: disable=no-name-in-module
 import pandas
 from music21 import stream, note, duration
+import outputlilypond
+from outputlilypond import settings as oly_settings
 from vis.analyzers import experimenter
-
-try:
-    import outputlilypond
-    from outputlilypond import settings as oly_settings
-except ImportError:
-    pass
 
 
 def annotate_the_note(obj):

--- a/vis/optional_requirements.txt
+++ b/vis/optional_requirements.txt
@@ -22,6 +22,3 @@ pylint
 mock==1.0.1
 coverage
 python-coveralls
-
-# To produce LilyPond documents with VIS events annotated.
-outputlilypond

--- a/vis/travis_requirements.txt
+++ b/vis/travis_requirements.txt
@@ -4,7 +4,6 @@ music21==2.1.2
 pandas==0.18.1
 multi_key_dict==2.0.3
 requests==2.11.1
-outputlilypond
 
 # For plotting.
 # scipy==0.16.0


### PR DESCRIPTION
Reverts ELVIS-Project/vis-framework#436 because score output is still not functional with this in, and it conflicts with the removal of outputlilypond.